### PR TITLE
Change Dependabot update schedule to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,12 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
-    auto-merge: true
+      interval: 'daily'
     commit-message:
       prefix: 'npm'
-    open-pull-requests-limit: 10
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
-    auto-merge: true
+      interval: 'daily'
     commit-message:
       prefix: 'github-actions'
-    open-pull-requests-limit: 10


### PR DESCRIPTION
Update the Dependabot configuration to change the update schedule for npm and GitHub Actions from weekly to daily.