### PR TITLE
Remove approval step from auto-merge process

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -83,7 +83,6 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr review --approve "$PR_URL"
           gh pr merge "$PR_URL" --auto --merge
 
       - name: Summarize workflow outcome


### PR DESCRIPTION
Eliminate the approval step in the auto-merge workflow to streamline the merging of pull requests.