### PR TITLE
Refactor platform architecture mapping and type definitions

### DIFF
--- a/dist/docker-command.d.ts
+++ b/dist/docker-command.d.ts
@@ -29,4 +29,4 @@ export declare function loadImageFromTar(tarPath: string): Promise<boolean>;
  * @param platform - Optional platform string (e.g., 'linux/amd64')
  * @returns Promise resolving to boolean indicating success or failure
  */
-export declare function pullImage(imageName: string, platform?: string): Promise<boolean>;
+export declare function pullImage(imageName: string, platform: string | undefined): Promise<boolean>;

--- a/dist/docker-compose-file.d.ts
+++ b/dist/docker-compose-file.d.ts
@@ -3,7 +3,7 @@
  */
 export type ComposeService = {
     readonly image: string;
-    readonly platform?: string;
+    readonly platform: string | undefined;
 };
 /**
  * Extracts Docker Compose services from specified files and filters them

--- a/dist/platform.d.ts
+++ b/dist/platform.d.ts
@@ -13,7 +13,7 @@ export type PlatformInfo = {
     /** The normalized OCI architecture identifier (e.g., 'amd64', 'arm64'). */
     readonly arch: string;
     /** The normalized OCI architecture variant identifier (e.g., 'v7', 'v8'), if applicable. */
-    readonly variant?: string;
+    readonly variant: string | undefined;
 };
 /**
  * Determines the OCI platform string (os/arch[/variant]) for the current Node.js runtime.
@@ -27,7 +27,7 @@ export declare function getCurrentOciPlatformString(): string | undefined;
  * @param ociPlatformString - The platform string to parse (e.g., "linux/amd64", "windows/amd64/v8").
  * @returns A `PlatformInfo` object, or `undefined` if the string is invalid.
  */
-export declare function parsePlatformString(ociPlatformString?: string): PlatformInfo | undefined;
+export declare function parsePlatformString(ociPlatformString: string | undefined): PlatformInfo | undefined;
 /**
  * Retrieves the OCI platform information (`PlatformInfo`) for the current Node.js runtime.
  *

--- a/src/docker-command.ts
+++ b/src/docker-command.ts
@@ -7,8 +7,8 @@ import * as exec from '@actions/exec';
 type DockerPlatform = {
   readonly architecture: string;
   readonly os: string;
-  readonly variant?: string;
-  readonly 'os.version'?: string;
+  readonly variant: string | undefined;
+  readonly 'os.version': string | undefined;
 };
 
 /**
@@ -18,8 +18,8 @@ type DockerManifestEntry = {
   readonly mediaType: string;
   readonly digest: string;
   readonly size: number;
-  readonly platform?: DockerPlatform;
-  readonly annotations?: Record<string, string>;
+  readonly platform: DockerPlatform | undefined;
+  readonly annotations: Record<string, string> | undefined;
 };
 
 /**
@@ -141,7 +141,7 @@ export async function loadImageFromTar(tarPath: string): Promise<boolean> {
  * @param platform - Optional platform string (e.g., 'linux/amd64')
  * @returns Promise resolving to boolean indicating success or failure
  */
-export async function pullImage(imageName: string, platform?: string): Promise<boolean> {
+export async function pullImage(imageName: string, platform: string | undefined): Promise<boolean> {
   try {
     const execOptions = { ignoreReturnCode: true };
     // Construct args array conditionally including platform flag if specified

--- a/src/docker-compose-file.ts
+++ b/src/docker-compose-file.ts
@@ -7,14 +7,14 @@ import * as yaml from 'js-yaml';
  */
 export type ComposeService = {
   readonly image: string;
-  readonly platform?: string;
+  readonly platform: string | undefined;
 };
 
 /**
  * Represents the structure of a Docker Compose file
  */
 type ComposeFile = {
-  readonly services?: Record<string, ComposeService>;
+  readonly services: Record<string, ComposeService> | undefined;
 };
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,9 +17,9 @@ type ServiceProcessingResult = {
   readonly restoredFromCache: boolean;
   readonly imageName: string;
   readonly cacheKey: string;
-  readonly digest?: string;
-  readonly platform?: string;
-  readonly error?: string;
+  readonly digest: string | undefined;
+  readonly platform: string | undefined;
+  readonly error: string | undefined;
 };
 
 /**
@@ -37,7 +37,7 @@ function generateCacheKey(
   imageName: string,
   imageTag: string,
   imageDigest: string,
-  servicePlatformString?: string
+  servicePlatformString: string | undefined
 ): string {
   // Sanitize components to ensure valid cache key
   const sanitizedImageName = sanitizePathComponent(imageName);
@@ -66,7 +66,7 @@ function generateTarPath(
   imageName: string,
   imageTag: string,
   imageDigest: string,
-  servicePlatformString?: string
+  servicePlatformString: string | undefined
 ): string {
   const tarFileName = generateCacheKey('', imageName, imageTag, imageDigest, servicePlatformString);
   return path.join(process.env.RUNNER_TEMP || '/tmp', `${tarFileName}.tar`);
@@ -100,6 +100,7 @@ async function processService(
       cacheKey: '',
       digest: undefined,
       platform: serviceDefinition.platform,
+      error: `Could not get digest for ${fullImageName}`,
     };
   }
 
@@ -131,6 +132,7 @@ async function processService(
       cacheKey: serviceCacheKey,
       digest: imageDigest,
       platform: serviceDefinition.platform,
+      error: loadSuccess ? undefined : `Failed to load image from cache: ${fullImageName}`,
     };
   }
 
@@ -146,6 +148,7 @@ async function processService(
       cacheKey: serviceCacheKey,
       digest: imageDigest,
       platform: serviceDefinition.platform,
+      error: `Failed to pull image: ${fullImageName}`,
     };
   }
 
@@ -160,6 +163,7 @@ async function processService(
       cacheKey: serviceCacheKey,
       digest: imageDigest,
       platform: serviceDefinition.platform,
+      error: `Digest mismatch for ${fullImageName}: expected ${imageDigest}, got ${newImageDigest}`,
     };
   }
 
@@ -174,6 +178,7 @@ async function processService(
       cacheKey: serviceCacheKey,
       digest: imageDigest,
       platform: serviceDefinition.platform,
+      error: `Failed to save image to tar: ${fullImageName}`,
     };
   }
 
@@ -195,6 +200,7 @@ async function processService(
       cacheKey: serviceCacheKey,
       digest: imageDigest,
       platform: serviceDefinition.platform,
+      error: undefined,
     };
   } catch (cacheError) {
     // Handle known cache saving errors gracefully without failing the operation
@@ -216,6 +222,7 @@ async function processService(
       cacheKey: serviceCacheKey,
       digest: imageDigest,
       platform: serviceDefinition.platform,
+      error: undefined,
     };
   }
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -22,64 +22,65 @@ export type PlatformInfo = {
  * Includes common aliases.
  * @see https://nodejs.org/api/process.html#processarch
  */
-const NODE_TO_OCI_ARCH_MAP: ReadonlyMap<string, string> = new Map([
-  ['x64', 'amd64'],
-  ['arm64', 'arm64'],
-  ['ia32', '386'],
-  ['arm', 'arm'],
-  ['ppc64', 'ppc64le'],
-  ['s390x', 's390x'],
-  ['mips', 'mips'],
-  ['mipsel', 'mipsle'],
-  ['loong64', 'loong64'],
-  ['riscv64', 'riscv64'],
+const NODE_TO_OCI_ARCH: Readonly<Record<string, string>> = {
+  // Node.js architectures
+  x64: 'amd64',
+  arm64: 'arm64',
+  ia32: '386',
+  arm: 'arm',
+  ppc64: 'ppc64le',
+  s390x: 's390x',
+  mips: 'mips',
+  mipsel: 'mipsle',
+  loong64: 'loong64',
+  riscv64: 'riscv64',
   // Aliases
-  ['aarch64', 'arm64'],
-  ['x86_64', 'amd64'],
-  ['x86', '386'],
-  ['ppc', 'ppc'],
-  ['s390', 's390'],
-  ['mips64el', 'mips64le'],
-]);
+  aarch64: 'arm64',
+  x86_64: 'amd64',
+  x86: '386',
+  ppc: 'ppc',
+  s390: 's390',
+  mips64el: 'mips64le',
+} as const;
 
 /** A set containing all valid OCI architecture values derived from the map. */
-const VALID_OCI_ARCHS: ReadonlySet<string> = new Set(NODE_TO_OCI_ARCH_MAP.values());
+const VALID_OCI_ARCHS: ReadonlySet<string> = new Set(Object.values(NODE_TO_OCI_ARCH));
 
 /**
  * Maps Node.js platform identifiers (`process.platform`) to their OCI OS equivalents.
  * @see https://nodejs.org/api/process.html#processplatform
  */
-const NODE_TO_OCI_OS_MAP: ReadonlyMap<string, string> = new Map([
-  ['linux', 'linux'],
-  ['win32', 'windows'],
-  ['darwin', 'darwin'],
-  ['aix', 'aix'],
-  ['freebsd', 'freebsd'],
-  ['openbsd', 'openbsd'],
-  ['sunos', 'solaris'],
-  ['android', 'android'],
-]);
+const NODE_TO_OCI_OS: Readonly<Record<string, string>> = {
+  linux: 'linux',
+  win32: 'windows',
+  darwin: 'darwin',
+  aix: 'aix',
+  freebsd: 'freebsd',
+  openbsd: 'openbsd',
+  sunos: 'solaris',
+  android: 'android',
+} as const;
 
 /** A set containing all valid OCI OS values derived from the map. */
-const VALID_OCI_OSS: ReadonlySet<string> = new Set(NODE_TO_OCI_OS_MAP.values());
+const VALID_OCI_OSS: ReadonlySet<string> = new Set(Object.values(NODE_TO_OCI_OS));
 
 /**
  * Maps Node.js specific ARM version identifiers or explicit variant strings
  * to their canonical OCI variant equivalents.
  */
-const NODE_TO_OCI_VARIANT_MAP: ReadonlyMap<string, string> = new Map([
+const NODE_TO_OCI_VARIANT: Readonly<Record<string, string>> = {
   // Node.js `arm_version` specific values
-  ['6', 'v6'],
-  ['7', 'v7'],
+  '6': 'v6',
+  '7': 'v7',
   // Explicit OCI variants (allow passthrough)
-  ['v5', 'v5'],
-  ['v6', 'v6'],
-  ['v7', 'v7'],
-  ['v8', 'v8'],
-]);
+  v5: 'v5',
+  v6: 'v6',
+  v7: 'v7',
+  v8: 'v8',
+} as const;
 
 /** A set containing all valid OCI variant values derived from the map. */
-const VALID_OCI_VARIANTS: ReadonlySet<string> = new Set(NODE_TO_OCI_VARIANT_MAP.values());
+const VALID_OCI_VARIANTS: ReadonlySet<string> = new Set(Object.values(NODE_TO_OCI_VARIANT));
 
 /**
  * Internal helper to resolve an OCI architecture identifier.
@@ -89,7 +90,13 @@ const VALID_OCI_VARIANTS: ReadonlySet<string> = new Set(NODE_TO_OCI_VARIANT_MAP.
  */
 function resolveOciArch(arch?: string): string | undefined {
   if (!arch) return undefined;
-  return NODE_TO_OCI_ARCH_MAP.get(arch) ?? (VALID_OCI_ARCHS.has(arch) ? arch : undefined);
+
+  // Safely check existence before accessing the property
+  if (arch in NODE_TO_OCI_ARCH) {
+    return NODE_TO_OCI_ARCH[arch as keyof typeof NODE_TO_OCI_ARCH];
+  }
+
+  return VALID_OCI_ARCHS.has(arch) ? arch : undefined;
 }
 
 /**
@@ -100,7 +107,13 @@ function resolveOciArch(arch?: string): string | undefined {
  */
 function resolveOciOs(os?: string): string | undefined {
   if (!os) return undefined;
-  return NODE_TO_OCI_OS_MAP.get(os) ?? (VALID_OCI_OSS.has(os) ? os : undefined);
+
+  // Safely check existence before accessing the property
+  if (os in NODE_TO_OCI_OS) {
+    return NODE_TO_OCI_OS[os as keyof typeof NODE_TO_OCI_OS];
+  }
+
+  return VALID_OCI_OSS.has(os) ? os : undefined;
 }
 
 /**
@@ -111,7 +124,13 @@ function resolveOciOs(os?: string): string | undefined {
  */
 function resolveOciVariant(variant?: string): string | undefined {
   if (!variant) return undefined;
-  return NODE_TO_OCI_VARIANT_MAP.get(variant) ?? (VALID_OCI_VARIANTS.has(variant) ? variant : undefined);
+
+  // Safely check existence before accessing the property
+  if (variant in NODE_TO_OCI_VARIANT) {
+    return NODE_TO_OCI_VARIANT[variant as keyof typeof NODE_TO_OCI_VARIANT];
+  }
+
+  return VALID_OCI_VARIANTS.has(variant) ? variant : undefined;
 }
 
 /**

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -14,7 +14,7 @@ export type PlatformInfo = {
   /** The normalized OCI architecture identifier (e.g., 'amd64', 'arm64'). */
   readonly arch: string;
   /** The normalized OCI architecture variant identifier (e.g., 'v7', 'v8'), if applicable. */
-  readonly variant?: string;
+  readonly variant: string | undefined;
 };
 
 /**
@@ -88,7 +88,7 @@ const VALID_OCI_VARIANTS: ReadonlySet<string> = new Set(Object.values(NODE_TO_OC
  * @param arch - The architecture string to map (Node.js or OCI).
  * @returns The canonical OCI architecture string or `undefined`.
  */
-function resolveOciArch(arch?: string): string | undefined {
+function resolveOciArch(arch: string | undefined): string | undefined {
   if (!arch) return undefined;
 
   // Safely check existence before accessing the property
@@ -105,7 +105,7 @@ function resolveOciArch(arch?: string): string | undefined {
  * @param os - The OS string to map (Node.js or OCI).
  * @returns The canonical OCI OS string or `undefined`.
  */
-function resolveOciOs(os?: string): string | undefined {
+function resolveOciOs(os: string | undefined): string | undefined {
   if (!os) return undefined;
 
   // Safely check existence before accessing the property
@@ -122,7 +122,7 @@ function resolveOciOs(os?: string): string | undefined {
  * @param variant - The variant string to map (Node.js arm_version or OCI).
  * @returns The canonical OCI variant string or `undefined`.
  */
-function resolveOciVariant(variant?: string): string | undefined {
+function resolveOciVariant(variant: string | undefined): string | undefined {
   if (!variant) return undefined;
 
   // Safely check existence before accessing the property
@@ -164,7 +164,7 @@ export function getCurrentOciPlatformString(): string | undefined {
  * @param ociPlatformString - The platform string to parse (e.g., "linux/amd64", "windows/amd64/v8").
  * @returns A `PlatformInfo` object, or `undefined` if the string is invalid.
  */
-export function parsePlatformString(ociPlatformString?: string): PlatformInfo | undefined {
+export function parsePlatformString(ociPlatformString: string | undefined): PlatformInfo | undefined {
   if (!ociPlatformString) {
     return undefined;
   }
@@ -187,10 +187,11 @@ export function parsePlatformString(ociPlatformString?: string): PlatformInfo | 
     return undefined;
   }
 
+  // Always include variant property, even if it's undefined
   const platformInfo: PlatformInfo = {
     os: resolvedOs,
     arch: resolvedArch,
-    ...(resolvedVariant && { variant: resolvedVariant }),
+    variant: resolvedVariant,
   };
   return platformInfo;
 }

--- a/tests/docker-command.test.ts
+++ b/tests/docker-command.test.ts
@@ -148,7 +148,7 @@ describe('Docker Command Module', () => {
       // Mock successful execution
       (exec.exec as jest.Mock).mockResolvedValue(0);
 
-      const pullSuccessful = await pullImage('nginx:latest');
+      const pullSuccessful = await pullImage('nginx:latest', undefined);
 
       expect(pullSuccessful).toBe(true);
       expect(exec.exec).toHaveBeenCalledWith('docker', ['pull', 'nginx:latest'], expect.any(Object));
@@ -158,7 +158,7 @@ describe('Docker Command Module', () => {
       // Mock failed execution
       (exec.exec as jest.Mock).mockResolvedValue(1);
 
-      const pullSuccessful = await pullImage('invalid:image');
+      const pullSuccessful = await pullImage('invalid:image', undefined);
 
       expect(pullSuccessful).toBe(false);
       expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('Failed to pull image'));


### PR DESCRIPTION
Replace Maps with Records for architecture mapping and update type definitions to use 'string | undefined' for improved type clarity and performance. This enhances code readability and type safety across the platform.