### PR TITLE
Update Node.js version in CI workflows

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -12,7 +12,7 @@ jobs:
   auto-merge-dependabot-prs:
     name: Auto-Merge Dependabot Dependency PR
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' && (startsWith(github.event.pull_request.title, 'npm') || startsWith(github.event.pull_request.title, 'github-actions')) && github.event.pull_request.draft == false
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false
     permissions:
       contents: write
       pull-requests: write
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
Change Node.js version from 20 to 22 in the auto-merge and CI workflows for consistency.