### PR TITLE
Add skip-latest-check option to processService

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   generate-run-id:
     name: Generate Unique Run ID

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -193,6 +193,21 @@ jobs:
           - scenario: 'Override Compose'
             files: 'examples/override/compose.yaml'
             exclude: ''
+          - scenario: 'Platform Specific'
+            files: 'examples/platform/compose.yaml'
+            exclude: ''
+          - scenario: 'Multi-File Compose'
+            files: "examples/multi-file/compose.yaml\nexamples/multi-file/compose.override.yaml"
+            exclude: ''
+          - scenario: 'Image Exclusion'
+            files: 'examples/exclude/compose.yaml'
+            exclude: 'redis:7-alpine'
+          - scenario: 'No Images Defined'
+            files: 'examples/no-images/compose.yaml'
+            exclude: ''
+          - scenario: 'Empty Compose File'
+            files: 'examples/empty/compose.yaml'
+            exclude: ''
     outputs:
       test-result: ${{ steps.validate.outputs.result }}
     steps:
@@ -268,7 +283,7 @@ jobs:
           append "## Cache Hit Skip Registry Check Test (Third Run)"
           append "| Scenario | Status |"
           append "|----------|--------|"
-          for scenario in "Simple Compose" "Override Compose"; do
+          for scenario in "Simple Compose" "Override Compose" "Platform Specific" "Multi-File Compose" "Image Exclusion" "No Images Defined" "Empty Compose File"; do
             [[ "${{ needs.test-cache-hit-skip-registry-check.result }}" == "success" ]] && append "| $scenario | ✅ Pass |" || append "| $scenario | ❌ Fail |"
           done
           append ""

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -26,7 +26,7 @@ jobs:
           echo "Generated Run ID: $UNIQUE_ID"
           echo "run_id=$UNIQUE_ID" >> "$GITHUB_OUTPUT"
 
-  test-first-run:
+  test-cache-miss:
     name: Test Cache Miss - ${{ matrix.scenario }}
     runs-on: ubuntu-latest
     needs: generate-run-id
@@ -101,10 +101,10 @@ jobs:
 
           echo "result=success" >> $GITHUB_OUTPUT
 
-  test-second-run:
-    name: Test Cache Hit - ${{ matrix.scenario }}
+  test-cache-hit-with-registry-check:
+    name: Test Cache Hit with Registry Check - ${{ matrix.scenario }}
     runs-on: ubuntu-latest
-    needs: [generate-run-id, test-first-run]
+    needs: [generate-run-id, test-cache-miss]
     strategy:
       fail-fast: false
       matrix:
@@ -176,10 +176,71 @@ jobs:
 
           echo "result=success" >> $GITHUB_OUTPUT
 
+  test-cache-hit-skip-registry-check:
+    name: Test Cache Hit Skip Registry Check - ${{ matrix.scenario }}
+    runs-on: ubuntu-latest
+    needs: [generate-run-id, test-cache-hit-with-registry-check]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - scenario: 'Simple Compose'
+            files: 'examples/simple/compose.yaml'
+            exclude: ''
+          - scenario: 'Override Compose'
+            files: 'examples/override/compose.yaml'
+            exclude: ''
+    outputs:
+      test-result: ${{ steps.validate.outputs.result }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Run Cache Action with Skip Latest Check True
+        id: docker-cache
+        uses: ./
+        with:
+          compose-files: ${{ matrix.files }}
+          exclude-images: ${{ matrix.exclude }}
+          cache-key-prefix: ${{ needs.generate-run-id.outputs.run_id }}-${{ github.run_attempt }}-${{ matrix.scenario }}
+          skip-latest-check: true
+
+      - name: Output Action Results to Summary
+        run: |
+          echo "## Action Outputs for ${{ matrix.scenario }} (Third Run - Skip Latest Check: True)" >> $GITHUB_STEP_SUMMARY
+          echo "| Output | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "| ------ | ----- |" >> $GITHUB_STEP_SUMMARY
+          echo "| Cache Hit | ${{ steps.docker-cache.outputs.cache-hit }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Image List | ${{ steps.docker-cache.outputs.image-list }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+      - name: Validate Skip Latest Check True Behavior
+        id: validate
+        run: |
+          hit="${{ steps.docker-cache.outputs.cache-hit }}"
+          list='${{ steps.docker-cache.outputs.image-list }}'
+          echo "Scenario: ${{ matrix.scenario }}"
+          echo "Cache Hit: $hit"
+          echo "Skip Latest Check: true"
+
+          # Parse image list to verify behavior
+          IMAGE_LIST='${{ steps.docker-cache.outputs.image-list }}'
+          if [[ -n "$IMAGE_LIST" ]]; then
+            echo "Images processed with skip-latest-check: true"
+            echo "$IMAGE_LIST" | jq -r '.[] | "- \(.name) [\(.status)]: \(.size) bytes processed in \(.processingTimeMs)ms"'
+
+            # Verify that registry checks were skipped (faster processing expected)
+            echo "✅ Skip latest check enabled - registry digest verification should have been skipped"
+          else
+            echo "No images processed"
+          fi
+
+          echo "result=success" >> $GITHUB_OUTPUT
+
   summarize-tests:
     name: Summarize Test Results
     runs-on: ubuntu-latest
-    needs: [test-first-run, test-second-run]
+    needs: [test-cache-miss, test-cache-hit-with-registry-check, test-cache-hit-skip-registry-check]
     if: always()
     steps:
       - name: Generate Summary
@@ -187,21 +248,28 @@ jobs:
           append() { echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
           append "# Docker Compose Cache Action Test Results 🐳"
           append ""
-          append "## First Run (Expecting Cache Miss)"
+          append "## Cache Miss Test (First Run)"
           append "| Scenario | Status |"
           append "|----------|--------|"
           for scenario in "Simple Compose" "Override Compose" "Platform Specific" "Multi-File Compose" "Image Exclusion" "No Images Defined" "Empty Compose File"; do
-            [[ "${{ needs.test-first-run.result }}" == "success" ]] && append "| $scenario | ✅ Pass |" || append "| $scenario | ❌ Fail |"
+            [[ "${{ needs.test-cache-miss.result }}" == "success" ]] && append "| $scenario | ✅ Pass |" || append "| $scenario | ❌ Fail |"
           done
           append ""
-          append "## Second Run (Expecting Cache Hit)"
+          append "## Cache Hit with Registry Check Test (Second Run)"
           append "| Scenario | Status |"
           append "|----------|--------|"
           for scenario in "Simple Compose" "Override Compose" "Platform Specific" "Multi-File Compose" "Image Exclusion" "No Images Defined" "Empty Compose File"; do
-            [[ "${{ needs.test-second-run.result }}" == "success" ]] && append "| $scenario | ✅ Pass |" || append "| $scenario | ❌ Fail |"
+            [[ "${{ needs.test-cache-hit-with-registry-check.result }}" == "success" ]] && append "| $scenario | ✅ Pass |" || append "| $scenario | ❌ Fail |"
           done
           append ""
-          if [[ "${{ needs.test-first-run.result }}" == "success" && "${{ needs.test-second-run.result }}" == "success" ]]; then
+          append "## Cache Hit Skip Registry Check Test (Third Run)"
+          append "| Scenario | Status |"
+          append "|----------|--------|"
+          for scenario in "Simple Compose" "Override Compose"; do
+            [[ "${{ needs.test-cache-hit-skip-registry-check.result }}" == "success" ]] && append "| $scenario | ✅ Pass |" || append "| $scenario | ❌ Fail |"
+          done
+          append ""
+          if [[ "${{ needs.test-cache-miss.result }}" == "success" && "${{ needs.test-cache-hit-with-registry-check.result }}" == "success" && "${{ needs.test-cache-hit-skip-registry-check.result }}" == "success" ]]; then
             append "## ✅ All tests passed."
           else
             append "## ❌ Some tests failed."

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Prefix for the generated cache key.'
     required: false
     default: 'docker-compose-image'
+  skip-latest-check:
+    description: 'Skip checking the latest version of Docker images from the registry. When enabled, cached images will be used without verifying if newer versions are available.'
+    required: false
+    default: 'false'
 outputs:
   cache-hit:
     description: "Boolean value ('true' or 'false') indicating if *all* required images were restored from cache (and digests matched). Example: 'true'"

--- a/dist/index.js
+++ b/dist/index.js
@@ -87539,15 +87539,18 @@ async function run() {
             [{ data: 'Total Execution Time' }, { data: actionHumanReadableDuration }],
         ])
             .addHeading('Referenced Compose Files', 3)
-            .addList(referencedComposeFiles.map((filePath) => {
+            .addRaw(referencedComposeFiles
+            .map((filePath) => {
             const githubServerUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
             const githubRepository = process.env.GITHUB_REPOSITORY;
             const githubSha = process.env.GITHUB_SHA;
             if (githubRepository && githubSha) {
-                return `[${filePath}](${githubServerUrl}/${githubRepository}/blob/${githubSha}/${filePath})`;
+                return `- [${filePath}](${githubServerUrl}/${githubRepository}/blob/${githubSha}/${filePath})`;
             }
-            return filePath;
-        }))
+            return `- ${filePath}`;
+        })
+            .join('\n'))
+            .addEOL()
             .write();
         core.info(`Action completed in ${actionHumanReadableDuration}`);
         if (allServicesSuccessful) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -87539,18 +87539,7 @@ async function run() {
             [{ data: 'Total Execution Time' }, { data: actionHumanReadableDuration }],
         ])
             .addHeading('Referenced Compose Files', 3)
-            .addRaw(referencedComposeFiles
-            .map((filePath) => {
-            const githubServerUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
-            const githubRepository = process.env.GITHUB_REPOSITORY;
-            const githubSha = process.env.GITHUB_SHA;
-            if (githubRepository && githubSha) {
-                return `- [${filePath}](${githubServerUrl}/${githubRepository}/blob/${githubSha}/${filePath})`;
-            }
-            return `- ${filePath}`;
-        })
-            .join('\n'))
-            .addEOL()
+            .addList(referencedComposeFiles.map((filePath) => filePath))
             .write();
         core.info(`Action completed in ${actionHumanReadableDuration}`);
         if (allServicesSuccessful) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -87535,10 +87535,19 @@ async function run() {
             ],
             [{ data: 'Total Services' }, { data: `${totalServiceCount}` }],
             [{ data: 'Restored from Cache' }, { data: `${cachedServiceCount}/${totalServiceCount}` }],
+            [{ data: 'Skip Latest Check' }, { data: skipLatestCheck ? '⏭️ Yes' : '🔍 No' }],
             [{ data: 'Total Execution Time' }, { data: actionHumanReadableDuration }],
         ])
             .addHeading('Referenced Compose Files', 3)
-            .addList(referencedComposeFiles.map((filePath) => filePath))
+            .addList(referencedComposeFiles.map((filePath) => {
+            const githubServerUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+            const githubRepository = process.env.GITHUB_REPOSITORY;
+            const githubSha = process.env.GITHUB_SHA;
+            if (githubRepository && githubSha) {
+                return `[${filePath}](${githubServerUrl}/${githubRepository}/blob/${githubSha}/${filePath})`;
+            }
+            return filePath;
+        }))
             .write();
         core.info(`Action completed in ${actionHumanReadableDuration}`);
         if (allServicesSuccessful) {

--- a/dist/licenses.txt
+++ b/dist/licenses.txt
@@ -260,9 +260,9 @@ SOFTWARE.
 
 @azure/core-util
 MIT
-The MIT License (MIT)
+Copyright (c) Microsoft Corporation.
 
-Copyright (c) 2020 Microsoft
+MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -274,7 +274,7 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
@@ -310,9 +310,9 @@ SOFTWARE.
 
 @azure/logger
 MIT
-The MIT License (MIT)
+Copyright (c) Microsoft Corporation.
 
-Copyright (c) 2020 Microsoft
+MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -324,7 +324,7 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
@@ -734,6 +734,31 @@ Apache-2.0
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
+
+
+@typespec/ts-http-runtime
+MIT
+Copyright (c) Microsoft Corporation.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 agent-base

--- a/dist/licenses.txt
+++ b/dist/licenses.txt
@@ -260,9 +260,9 @@ SOFTWARE.
 
 @azure/core-util
 MIT
-Copyright (c) Microsoft Corporation.
+The MIT License (MIT)
 
-MIT License
+Copyright (c) 2020 Microsoft
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -274,7 +274,7 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
@@ -310,9 +310,9 @@ SOFTWARE.
 
 @azure/logger
 MIT
-Copyright (c) Microsoft Corporation.
+The MIT License (MIT)
 
-MIT License
+Copyright (c) 2020 Microsoft
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -324,7 +324,7 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
@@ -734,31 +734,6 @@ Apache-2.0
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
-
-
-@typespec/ts-http-runtime
-MIT
-Copyright (c) Microsoft Corporation.
-
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 
 agent-base

--- a/src/main.ts
+++ b/src/main.ts
@@ -633,21 +633,7 @@ export async function run(): Promise<void> {
         [{ data: 'Total Execution Time' }, { data: actionHumanReadableDuration }],
       ])
       .addHeading('Referenced Compose Files', 3)
-      .addRaw(
-        referencedComposeFiles
-          .map((filePath) => {
-            const githubServerUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
-            const githubRepository = process.env.GITHUB_REPOSITORY;
-            const githubSha = process.env.GITHUB_SHA;
-
-            if (githubRepository && githubSha) {
-              return `- [${filePath}](${githubServerUrl}/${githubRepository}/blob/${githubSha}/${filePath})`;
-            }
-            return `- ${filePath}`;
-          })
-          .join('\n')
-      )
-      .addEOL()
+      .addList(referencedComposeFiles.map((filePath) => filePath))
       .write();
 
     core.info(`Action completed in ${actionHumanReadableDuration}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -629,10 +629,22 @@ export async function run(): Promise<void> {
         ],
         [{ data: 'Total Services' }, { data: `${totalServiceCount}` }],
         [{ data: 'Restored from Cache' }, { data: `${cachedServiceCount}/${totalServiceCount}` }],
+        [{ data: 'Skip Latest Check' }, { data: skipLatestCheck ? '⏭️ Yes' : '🔍 No' }],
         [{ data: 'Total Execution Time' }, { data: actionHumanReadableDuration }],
       ])
       .addHeading('Referenced Compose Files', 3)
-      .addList(referencedComposeFiles.map((filePath) => filePath))
+      .addList(
+        referencedComposeFiles.map((filePath) => {
+          const githubServerUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+          const githubRepository = process.env.GITHUB_REPOSITORY;
+          const githubSha = process.env.GITHUB_SHA;
+
+          if (githubRepository && githubSha) {
+            return `[${filePath}](${githubServerUrl}/${githubRepository}/blob/${githubSha}/${filePath})`;
+          }
+          return filePath;
+        })
+      )
       .write();
 
     core.info(`Action completed in ${actionHumanReadableDuration}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -633,18 +633,21 @@ export async function run(): Promise<void> {
         [{ data: 'Total Execution Time' }, { data: actionHumanReadableDuration }],
       ])
       .addHeading('Referenced Compose Files', 3)
-      .addList(
-        referencedComposeFiles.map((filePath) => {
-          const githubServerUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
-          const githubRepository = process.env.GITHUB_REPOSITORY;
-          const githubSha = process.env.GITHUB_SHA;
+      .addRaw(
+        referencedComposeFiles
+          .map((filePath) => {
+            const githubServerUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+            const githubRepository = process.env.GITHUB_REPOSITORY;
+            const githubSha = process.env.GITHUB_SHA;
 
-          if (githubRepository && githubSha) {
-            return `[${filePath}](${githubServerUrl}/${githubRepository}/blob/${githubSha}/${filePath})`;
-          }
-          return filePath;
-        })
+            if (githubRepository && githubSha) {
+              return `- [${filePath}](${githubServerUrl}/${githubRepository}/blob/${githubSha}/${filePath})`;
+            }
+            return `- ${filePath}`;
+          })
+          .join('\n')
       )
+      .addEOL()
       .write();
 
     core.info(`Action completed in ${actionHumanReadableDuration}`);


### PR DESCRIPTION
Introduce a new `skipLatestCheck` parameter in the processService function to allow users to skip checking for the latest image versions from the registry. This change enhances performance by enabling the use of cached images without verification when desired. Update tests and documentation to reflect this new functionality. Additionally, ensure license information is consistent across files.