### PR TITLE
Fix Dependabot auto-merge workflow checkout issue

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -18,6 +18,9 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Merge Dependabot PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add missing `actions/checkout@v4` step to the Dependabot auto-merge workflow
- Resolves the "fatal: not a git repository" error that was causing workflow failures
- Ensures GitHub CLI has proper repository context when executing commands

## Problem
The auto-merge workflow was failing with error:
```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

## Solution
Added repository checkout step before the GitHub CLI command to provide proper git context.

## Test plan
- [x] Verify workflow syntax is correct
- [ ] Test with actual Dependabot PR to confirm fix works

🤖 Generated with [Claude Code](https://claude.ai/code)