### PR TITLE
Fix Dependabot merge permission issue

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
## Summary
- Grant `contents: write` permission to allow Dependabot merge commands
- Fixes "Sorry, only users with push access can use that command" error

## Problem
The Dependabot auto-merge workflow was failing with:
```
Sorry, only users with push access can use that command.
```

## Solution
Updated workflow permissions from `contents: read` to `contents: write` to enable Dependabot merge functionality.

## Test plan
- [ ] Test with actual Dependabot PR to confirm merge command works

🤖 Generated with [Claude Code](https://claude.ai/code)