### PR TITLE
Fix Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -34,8 +34,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          # Wait for CI checks to pass
-          gh pr checks ${{ github.event.pull_request.number }} --watch
+          # Wait for CI checks to pass (30 minute timeout)
+          gh pr checks ${{ github.event.pull_request.number }} --watch --interval=30 --timeout=1800
           
           # Approve the PR first
           gh pr review ${{ github.event.pull_request.number }} --approve

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -30,8 +30,15 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Merge Dependabot PR
+      - name: Auto-merge Dependabot PR
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh pr comment ${{ github.event.pull_request.number }} --body "@dependabot merge"
+          # Wait for CI checks to pass
+          gh pr checks ${{ github.event.pull_request.number }} --watch
+          
+          # Approve the PR first
+          gh pr review ${{ github.event.pull_request.number }} --approve
+          
+          # Enable auto-merge with squash strategy
+          gh pr merge ${{ github.event.pull_request.number }} --auto --squash --delete-branch


### PR DESCRIPTION
## Summary
- Replace failing '@dependabot merge' command with GitHub CLI approach
- Fix auto-merge functionality that was blocked by GitHub App token limitations
- Enable auto-merge for all dependency update types (patch, minor, major)

## Changes
- Use 'gh pr merge --auto' instead of '@dependabot merge' comment
- Add CI check waiting with 'gh pr checks --watch'
- Include PR approval step before merge
- Configure squash merge with automatic branch deletion