### PR TITLE
chore: use rebase merge for dependabot auto-merge

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -68,7 +68,7 @@ jobs:
             --body "✅ Auto-approved ${{ steps.metadata.outputs.update-type }} update for ${{ steps.metadata.outputs.dependency-names }}"
 
           # Enable auto-merge
-          gh pr merge ${{ github.event.pull_request.number }} --auto --merge
+          gh pr merge ${{ github.event.pull_request.number }} --auto --rebase
           # Add success comment
           gh pr comment ${{ github.event.pull_request.number }} \
             --body "🚀 Auto-merge enabled for this ${{ steps.metadata.outputs.update-type }} update. Will merge once all checks pass."


### PR DESCRIPTION
## Summary
- Change auto-merge strategy from merge commit to rebase merge for Dependabot PRs
- This keeps commit history cleaner and more linear