### PR TITLE
chore: upgrade Node.js from 22 to 24

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Fetch Dependabot metadata
@@ -54,6 +55,31 @@ jobs:
           exit 1
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build and package
+        run: npm run package
+
+      - name: Commit dist changes if any
+        run: |
+          if ! git diff --exit-code --quiet dist/; then
+            git config --global user.name '${{ steps.generate_token.outputs.app-slug }}[bot]'
+            git config --global user.email '${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com'
+            git add dist/
+            git commit -m "build: update compiled action code"
+            git push
+            echo "Committed changes to dist/ directory"
+          else
+            echo "No changes detected in dist/ directory"
+          fi
 
       - name: Auto-approve and merge
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Upgrade Node.js version from 22 to 24 in CI workflow
- Add build and package steps to auto-merge-dependabot.yml
- Automatically commit dist/ changes for Dependabot PRs

## Changes
### ci.yaml
- Update `node-version` from `22` to `24`

### auto-merge-dependabot.yml
- Add `ref` to checkout PR branch directly
- Add Node.js 24 setup step
- Add `npm ci` to install dependencies
- Add `npm run package` to build
- Add step to commit dist/ changes if any