### PR TITLE
Stop CI from retriggering on generated commits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         run: npm run package
 
       - name: Commit generated files
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.head_commit.message != 'build: update generated files'"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         run: npm run package
 
       - name: Commit generated files
-        if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.head_commit.message != 'build: update generated files'"
+        if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'development-automation-bot[bot]'"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |


### PR DESCRIPTION
## Summary
- Prevent the CI workflow from running the dist/version commit step on its own generated bot commits.
- This breaks the self-triggering push chain that was incrementing release tags repeatedly.

## Why
- The repeated build: update generated files pushes were authored by the automation bot itself.
- Skipping the commit step for that specific head commit message stops the loop while preserving normal release behavior for real main-branch changes.
