### PR TITLE
ci: publish GitHub Release alongside the v{version} tag

### DIFF
--- a/.github/actions/sync-release-tags/action.yml
+++ b/.github/actions/sync-release-tags/action.yml
@@ -1,5 +1,5 @@
 name: Sync release tags
-description: Create the v{version} tag for the current commit and force v{major} to point at it.
+description: Create the v{version} tag and matching GitHub Release for the current commit, then force v{major} to point at it.
 
 inputs:
   bot-name:
@@ -7,6 +7,9 @@ inputs:
     required: true
   bot-email:
     description: Git user email used to author the tag objects.
+    required: true
+  github-token:
+    description: "Token used by the GitHub CLI to publish the Release. Needs `contents: write`."
     required: true
 
 runs:
@@ -17,6 +20,7 @@ runs:
       env:
         BOT_NAME: ${{ inputs.bot-name }}
         BOT_EMAIL: ${{ inputs.bot-email }}
+        GH_TOKEN: ${{ inputs.github-token }}
       run: |
         set -euo pipefail
 
@@ -46,6 +50,20 @@ runs:
         git tag -fa "${major_tag}" "${current_commit}" -m "chore(release): update ${major_tag} to ${version_tag}"
         git push --force origin "refs/tags/${major_tag}"
 
+        # Publish a GitHub Release for the patch tag the first time it shows
+        # up. The major tag is intentionally not promoted to a Release: it
+        # is a moving pointer, not a release artifact. The check is idempotent
+        # so re-runs (manual dispatch, retries) don't error.
+        if gh release view "${version_tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+          release_status="already existed"
+        else
+          gh release create "${version_tag}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${version_tag}" \
+            --generate-notes
+          release_status="created"
+        fi
+
         short_sha=$(git rev-parse --short "${current_commit}")
         {
           echo "### 📌 Release Tags"
@@ -54,4 +72,6 @@ runs:
           echo "|-----|------------|"
           echo "| \`${version_tag}\` | \`${short_sha}\` |"
           echo "| \`${major_tag}\` | \`${short_sha}\` |"
+          echo ""
+          echo "GitHub Release \`${version_tag}\`: ${release_status}."
         } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,7 @@ jobs:
         with:
           bot-name: ${{ steps.app-token.outputs.app-slug }}[bot]
           bot-email: ${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com
+          github-token: ${{ steps.app-token.outputs.token }}
 
   build-and-test-summary:
     name: Build and Test Summary

--- a/.github/workflows/update-major-version-tag.yml
+++ b/.github/workflows/update-major-version-tag.yml
@@ -37,3 +37,4 @@ jobs:
         with:
           bot-name: ${{ steps.app-token.outputs.app-slug }}[bot]
           bot-email: ${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com
+          github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Extend the `.github/actions/sync-release-tags` composite to publish a GitHub Release for the patch tag (`v{version}`) right after pushing it.
- The Release uses `gh release create --generate-notes` so the body is auto-populated from PRs / commits since the previous Release.
- Existence is checked first via `gh release view`, keeping the composite idempotent (manual `workflow_dispatch` re-runs and CI retries no longer error).
- Major tag (`v{major}`) is intentionally still tag-only; it moves on every patch release and isn't a Release artifact.
- Both `ci.yaml` and the manual fallback `update-major-version-tag.yml` now pass the existing App installation token through to the composite as a new `github-token` input. `GH_TOKEN` is exported only inside the composite's run step.

## Context
v1.8.1 / v1.8.2 ended up as tag-only releases because the previous composite never called the Releases API. I backfilled those two manually (`gh release create ... --generate-notes`); from this PR onward the flow is fully automatic.

## Test plan
- [ ] PR CI passes (lint / tests / build / package).
- [ ] After merge, CI on `main` does **not** push a spurious `build: update generated files` commit (this PR touches only workflows / composite, dist/ is unaffected).
- [ ] Trigger one more dependency-update merge (Dependabot/Renovate) and confirm that:
  - the bot version-bump commit lands,
  - `v1.8.3` and the updated `v1` tag appear,
  - a new GitHub Release `v1.8.3` is created with auto-generated notes that link the merged PR(s).
- [ ] Manual `workflow_dispatch` on `update-major-version-tag.yml` does not error when the Release already exists (idempotency check).