### PR TITLE
chore: preserve npm semver ranges and auto-merge action digest pins

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -11,6 +11,9 @@
     ":semanticCommits",
     ":semanticCommitTypeAll(chore)",
     ":semanticCommitScope(deps)",
+    // Keep npm semver ranges (the committed lockfile gives reproducibility); overrides
+    // best-practices dev-dependency pinning. Action digest pinning is unaffected.
+    ":preserveSemverRanges",
   ],
   timezone: "Asia/Tokyo",
   schedule: ["before 9am on monday"],
@@ -28,7 +31,7 @@
   packageRules: [
     {
       description: "Auto-merge non-major updates once CI passes",
-      matchUpdateTypes: ["minor", "patch", "pin", "digest"],
+      matchUpdateTypes: ["minor", "patch", "pin", "pinDigest", "digest"],
       automerge: true,
     },
     {


### PR DESCRIPTION
## Summary

Refine the shared Renovate policy after onboarding feedback:

- **Add `:preserveSemverRanges`** — keep npm dependencies on their semver ranges instead of pinning them. Reproducibility is already guaranteed by the committed lockfile, so pinning `package.json` only adds PR churn. This removes the noisy, identically-titled "pin dependencies" PRs for npm.
- **Add `pinDigest` to the auto-merge update types** — the one-time GitHub Action digest pin (tag → SHA) now auto-merges like other low-risk updates.

GitHub Action digest pinning (supply-chain safety from `config:best-practices`) is governed by `pinDigests` and is **unaffected** by `:preserveSemverRanges`; it stays on.

## Validation

- `renovate-config-validator` (v43) passes.

## Note

Already-merged one-time pin PRs are intentionally left as-is: `main` has advanced since they merged, so reverting would risk version downgrades and lockfile inconsistencies. `:preserveSemverRanges` stops further pinning going forward.
