### PR TITLE
ci: fail summary jobs when upstream jobs do not succeed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,7 +150,18 @@ jobs:
     name: Build and Test Summary
     runs-on: ubuntu-latest
     needs: build-and-test
+    # GitHub branch protection treats a `skipped` required check as
+    # non-failing, so the default `needs:` behavior (skip the summary when
+    # the upstream job fails) lets red builds slip past required-check
+    # rulesets. Always run the summary and turn the upstream conclusion
+    # into an explicit pass/fail so it correctly gates merges.
+    if: always()
     steps:
+      - name: Fail if build-and-test did not succeed
+        if: needs.build-and-test.result != 'success'
+        run: |
+          echo "::error::build-and-test concluded with '${{ needs.build-and-test.result }}'"
+          exit 1
       - name: Report successful completion
         run: |
           echo "### Build and Test Summary" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -293,3 +293,12 @@ jobs:
             append "## ❌ Some tests failed."
             append "### Check job logs for failure details."
           fi
+      - name: Fail if any upstream job did not succeed
+        # Without this, the job exits 0 even when the summary above says
+        # "Some tests failed", so the required check passes and a red CI
+        # can be merged. Convert any non-success upstream into an explicit
+        # job failure that branch protection will respect.
+        if: needs.test-cache-miss.result != 'success' || needs.test-cache-hit-with-registry-check.result != 'success' || needs.test-cache-hit-skip-registry-check.result != 'success'
+        run: |
+          echo "::error::upstream test jobs concluded with non-success results"
+          exit 1


### PR DESCRIPTION
## Summary

PR #298 — the `js-yaml ^4.1.1 → ^5.0.0` bump that broke `main` — got merged with `Build & Test` red. The root cause was a long-standing branch-protection escape hatch:

- The required check for `main` is `Build and Test Summary`, a downstream `needs: build-and-test` job whose only purpose is to emit a success banner.
- When `build-and-test` fails, GitHub auto-skips the downstream summary. **GitHub branch protection treats `skipped` as non-failing**, so the required check passes and the PR becomes mergeable.
- `Summarize Test Results` in `test-action.yml` already runs under `if: always()`, but it exits 0 even when its `needs:` jobs fail — the same hole in a different shape.

## Fix

Both summary jobs are now run unconditionally (`if: always()`) with an explicit step that exits 1 when any upstream job concluded non-`success`. The required checks now become **real failures** that branch protection will block on, with no ruleset change needed.

## Test plan

- [x] `prettier --check` on the modified workflow files
- [ ] CI green on this PR (positive case — upstream succeeds, summary still emits success)
- [ ] Optional follow-up: force a red `Build & Test` on a throwaway PR to confirm `Build and Test Summary` now fails

https://claude.ai/code/session_01RNhJEDyikaLxLKJnwqMZSd