### PR TITLE
fix: normalize line endings in generated licenses.txt

### DIFF
--- a/scripts/generate-licenses.mjs
+++ b/scripts/generate-licenses.mjs
@@ -23,7 +23,14 @@ function readLicenseText(packageDir) {
     return '';
   }
   const licenseFile = readdirSync(packageDir).find((name) => LICENSE_FILE_RE.test(name));
-  return licenseFile ? readFileSync(join(packageDir, licenseFile), 'utf8').trimEnd() : '';
+  if (!licenseFile) {
+    return '';
+  }
+  // Some packages ship CRLF license files (e.g. tslib). Normalize to LF so the
+  // regenerated output stays byte-identical to the committed file, which the
+  // repo-wide `* text=auto eol=lf` attribute normalizes on checkin. A mismatch
+  // here leaves the CI working tree dirty and blocks the release version bump.
+  return readFileSync(join(packageDir, licenseFile), 'utf8').replace(/\r\n?/g, '\n').trimEnd();
 }
 
 // `pnpm licenses list` groups production dependencies by SPDX identifier and reports


### PR DESCRIPTION
## Problem

Every `CI` run on `main` has failed at the **Bump version on main** step since e5b6515 with:

```
[ERR_PNPM_UNCLEAN_WORKING_TREE] Working tree is not clean. Commit or stash your changes.
```

## Root cause

- tslib ships its LICENSE file with CRLF line endings, and `scripts/generate-licenses.mjs` embeds the license text verbatim, so the regenerated `dist/licenses.txt` contains CRLF lines.
- The repo-wide `* text=auto eol=lf` attribute in `.gitattributes` normalized the committed `dist/licenses.txt` to LF at checkin.
- After `pnpm run package`, the regenerated file therefore always differs byte-wise from the index, `git status --porcelain` reports it as modified, and `pnpm version patch` refuses to run on the dirty tree.

## Fix

Normalize license text to LF (`\r\n?` → `\n`) when reading each package's license file, so regeneration is byte-identical to the committed, git-normalized file. No change to `dist/` is needed: the committed `dist/licenses.txt` already holds exactly the LF content the fixed script produces.

## Verification

Reproduced the failure and validated the fix on a clean clone of `main` (pnpm 11.11.0, the version CI effectively runs via `devEngines`):

- Before: `pnpm run package` → `git status` shows ` M dist/licenses.txt` (11 CRLF lines from tslib); `pnpm version patch --no-git-tag-version` fails with `ERR_PNPM_UNCLEAN_WORKING_TREE`.
- After: full CI chain (`install --frozen-lockfile`, `lint`, `format:check`, `typecheck`, `test`, `package`) leaves the tree clean; `pnpm version patch --no-git-tag-version` succeeds (1.8.17 → 1.8.18).

After merge, the next push to `main` should rebuild cleanly and the release automation (version bump → tag sync) should resume.