### PR TITLE
ci: do not fail summary when a main push run is superseded

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,11 +163,17 @@ jobs:
     if: always()
     steps:
       - name: Fail if build-and-test did not succeed
-        if: needs.build-and-test.result != 'success'
+        # A cancelled push run is expected on main: the version-bump commit
+        # pushed by the bot joins the same concurrency group and supersedes
+        # its own trigger run. Let that surface as `cancelled` instead of
+        # converting it into a failure. PR runs keep failing on cancellation
+        # so the required check stays strict.
+        if: needs.build-and-test.result != 'success' && !(github.event_name == 'push' && needs.build-and-test.result == 'cancelled')
         run: |
           echo "::error::build-and-test concluded with '${{ needs.build-and-test.result }}'"
           exit 1
       - name: Report successful completion
+        if: needs.build-and-test.result == 'success'
         run: |
           echo "### Build and Test Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Problem

Merging #309 restored the release automation, but each release now leaves a red ✗ run on `main`:

1. A push to `main` starts CI run A.
2. Run A bumps the version and pushes the bot commit.
3. The bot push starts run B in the same `ci-${{ github.ref }}` concurrency group, and `cancel-in-progress: true` cancels run A.
4. Run A's summary job (`if: always()`) treats result `cancelled` as non-success and fails, so the run concludes as **failure** instead of **cancelled**.

This happens on every release-triggering push (e.g. run 29790676831 for the #309 merge).

## Change

- `Fail if build-and-test did not succeed`: on `push` runs, no longer convert `cancelled` into a failure — the run then concludes as `cancelled` (superseded), which is what actually happened. `pull_request` runs keep failing on cancellation, so the required check for merges stays strict.
- `Report successful completion`: only claim success when `build-and-test` actually succeeded.

## Verification

- YAML parses; conditions use only trusted contexts (`github.event_name`, `needs.*.result`).
- Behavior change is observable on the next release-triggering push to `main`: the superseded run should show as cancelled, not failed.