### PR TITLE
fix(ci): resolve the pnpm version from packageManager only

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,13 +53,6 @@
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "11.13.1",
-      "onFail": "download"
-    }
-  },
   "engines": {
     "node": ">=24"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,11 @@
-# Renovate resolves and pins every dependency itself, so CI does not re-apply
-# `minimumReleaseAge` to entries the lockfile already records. Without this
-# setting `pnpm install --frozen-lockfile` rejects the lockfile Renovate wrote
-# whenever a release is under a day old. Resolution-time cooldown and
-# Renovate's own three-day hold remain in place.
+# Trust the resolutions the lockfile already records. The setting applies to
+# every install, local and CI alike, so none of them re-apply
+# `minimumReleaseAge` to lockfile entries. Renovate writes the lockfile and
+# opens the pull request within hours of a publish, so without this setting
+# `pnpm install --frozen-lockfile` rejects the lockfile Renovate just produced.
+# The cooldown still applies when resolving a new version, and Renovate's
+# three-day hold still gates the merge. The accepted trade-off is that a
+# lockfile arriving through a pull request is no longer re-audited.
 trustLockfile: true
 
 # Packages allowed to run install scripts (pnpm 11 blocks build scripts by default).

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
+# Renovate resolves and pins every dependency itself, so CI does not re-apply
+# `minimumReleaseAge` to entries the lockfile already records. Without this
+# setting `pnpm install --frozen-lockfile` rejects the lockfile Renovate wrote
+# whenever a release is under a day old. Resolution-time cooldown and
+# Renovate's own three-day hold remain in place.
+trustLockfile: true
+
 # Packages allowed to run install scripts (pnpm 11 blocks build scripts by default).
 # lefthook's postinstall installs its platform binary, which `prepare` (lefthook
 # install) needs. No other dependency requires a build (biome 2.x has no install


### PR DESCRIPTION
## Summary

- Delete the `devEngines` block from `package.json` so `packageManager` is the single source for the pnpm version.
- Set `trustLockfile: true` in `pnpm-workspace.yaml`.

## Why: the two pnpm versions disagreed

`package.json` declared the pnpm version twice, with different values:

```json
"packageManager": "pnpm@11.17.0"
"devEngines": { "packageManager": { "name": "pnpm", "version": "11.13.1", "onFail": "download" } }
```

`pnpm/action-setup` prefers `devEngines.packageManager` over `packageManager`, matching pnpm's own `getWantedPackageManager` logic. The action raises `Multiple versions of pnpm specified` only when its `version` **input** disagrees with `packageManager` — a `devEngines` mismatch raises nothing. CI has therefore been running pnpm 11.13.1 while `package.json` advertised 11.17.0.

Renovate's npm manager updates `packageManager` but not `devEngines`, so setting both to 11.17.0 would drift again on the next bump. Deleting `devEngines` leaves one value that Renovate keeps current.

`seijikohara/vizel` hit the loud variant of the same class of bug: the `version` input drifted from `packageManager` and broke its `Quality` workflow on main for over a week (seijikohara/vizel#717).

## Why: `trustLockfile`

pnpm 11 defaults `minimumReleaseAge` to one day and `trustLockfile` to `false`, so `pnpm install --frozen-lockfile` re-verifies every lockfile entry and rejects anything published within the last day:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] lockfile entries failed verification
```

Renovate writes that lockfile and opens the pull request within hours of a publish. `minimumReleaseAge: "3 days"` in `renovate.json5` does not stop it: when every candidate version fails the age check, `internalChecksFilter` (default `strict`) returns the newest one with `pendingChecks` set rather than withholding the update, so the branch is created and only `renovate/stability-days` goes pending.

Resolution-time cooldown and Renovate's three-day hold still gate which versions reach the lockfile. The trade-off is that CI no longer re-audits a lockfile supplied by a pull request.

## Test Plan

- [x] Run `pnpm install --frozen-lockfile` locally; pnpm accepts `trustLockfile` and resolves 11.17.0.
- [ ] Confirm CI passes on this pull request.
- [ ] Confirm a CI job log shows pnpm 11.17.0 rather than 11.13.1.
