### PR TITLE
fix(renovate): ignore the dist-commit bot author

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -20,6 +20,10 @@
   labels: ['dependencies'],
   // This repository is a JavaScript (Node.js) GitHub Action.
   enabledManagers: ['npm', 'github-actions'],
+  // CI commits the built `dist/` back onto the pull request branch. Without this,
+  // Renovate reads that commit as a manual edit, marks the pull request
+  // "PR Edited (Blocked)" on the dependency dashboard, and stops rebasing it.
+  gitIgnoredAuthors: ['development-automation-bot[bot]@users.noreply.github.com'],
   // Keep update branches rebased on main and merge via rebase once CI passes.
   rebaseWhen: 'behind-base-branch',
   platformAutomerge: true,


### PR DESCRIPTION
## Summary

Add `gitIgnoredAuthors` so Renovate stops treating the CI dist-commit as a manual edit.

## Problem

The `Commit dist to PR branch` step in `.github/workflows/ci.yaml` pushes the
built output back onto the pull request branch:

```yaml
git commit -m "build: update generated files"
git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:refs/heads/${PR_BRANCH}"
```

That commit is authored by `development-automation-bot[bot]`. Renovate treats a
commit by any other Git author as a manual edit to the branch, so it moved the
affected pull request into the **PR Edited (Blocked)** section of the dependency
dashboard:

> The following updates have been manually edited so Renovate will no longer
> make changes. To discard all commits and start over, click on a checkbox below.

Once blocked, Renovate stops rebasing the branch entirely. `rebaseWhen:
'behind-base-branch'` no longer applies and the pull request sits permanently
in the `BEHIND` merge state, which also prevents `platformAutomerge` from
completing it.

## Changes

### Added

- `renovate.json5`: `gitIgnoredAuthors: ['development-automation-bot[bot]@users.noreply.github.com']`

This is the documented option for exactly this situation. Per the Renovate
configuration reference:

> By default, Renovate treats any PR as modified if another Git author has
> committed to the branch [...] Adding other Git authors to `gitIgnoredAuthors`
> prevents Renovate from treating PRs as modified when those authors commit to
> the branch.

The author address was taken from the actual commit on the blocked branch, not
inferred: the workflow derives it as `${app-slug}[bot]@users.noreply.github.com`.

## Test Plan

- [x] `renovate-config-validator` reports `Config validated successfully`
- [ ] After merge, Renovate rebases the blocked lock file maintenance pull request instead of leaving it in the PR Edited section